### PR TITLE
Trust GitHub SSH host in Docker jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,13 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: trust github ssh host
+          command: |
+            mkdir -p ~/.ssh
+            printf '%s\n' 'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl' >> ~/.ssh/known_hosts
+            chmod 700 ~/.ssh
+            chmod 600 ~/.ssh/known_hosts
+      - run:
           name: build and push images
           command: |
             echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USER" --password-stdin
@@ -112,6 +119,13 @@ jobs:
       - setup_remote_docker
       - attach_workspace:
           at: ~/
+      - run:
+          name: trust github ssh host
+          command: |
+            mkdir -p ~/.ssh
+            printf '%s\n' 'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl' >> ~/.ssh/known_hosts
+            chmod 700 ~/.ssh
+            chmod 600 ~/.ssh/known_hosts
       - run:
           name: build and push images
           command: |


### PR DESCRIPTION
## Summary
- add GitHub's pinned SSH host key to known_hosts before CircleCI Docker build/push jobs
- avoids interactive authenticity prompts when Docker or SSH touches github.com in CI

## Verification
- PR branch created from latest origin/master
- config change is limited to CircleCI Docker jobs